### PR TITLE
TASK: Throw exceptions if the afx-syntax is invalid

### DIFF
--- a/src/Exception.php
+++ b/src/Exception.php
@@ -1,0 +1,10 @@
+<?php
+namespace PackageFactory\Afx;
+
+/**
+ * AFX-Exception
+ */
+class Exception extends \Exception
+{
+
+}

--- a/src/Expression/Expression.php
+++ b/src/Expression/Expression.php
@@ -1,6 +1,7 @@
 <?php
 namespace PackageFactory\Afx\Expression;
 
+use PackageFactory\Afx\Exception;
 use PackageFactory\Afx\Lexer;
 
 class Expression
@@ -13,7 +14,11 @@ class Expression
             $lexer->consume();
         }
 
-        while (!$lexer->isEnd()) {
+        while (true) {
+            if ($lexer->isEnd()) {
+                throw new Exception('Unclosed Expression');
+            }
+
             if ($lexer->isOpeningBrace()) {
                 $braceCount++;
             }

--- a/src/Expression/Node.php
+++ b/src/Expression/Node.php
@@ -1,6 +1,7 @@
 <?php
 namespace PackageFactory\Afx\Expression;
 
+use PackageFactory\Afx\Exception;
 use PackageFactory\Afx\Lexer;
 
 class Node
@@ -78,6 +79,10 @@ class Node
                     'selfClosing' => false
                 ];
             }
+        }
+
+        if ($lexer->isEnd()) {
+            throw new Exception(sprintf('Tag %s was is not closed', $identifier));
         }
     }
 }

--- a/src/Expression/StringLiteral.php
+++ b/src/Expression/StringLiteral.php
@@ -1,6 +1,7 @@
 <?php
 namespace PackageFactory\Afx\Expression;
 
+use PackageFactory\Afx\Exception;
 use PackageFactory\Afx\Lexer;
 
 class StringLiteral
@@ -14,7 +15,11 @@ class StringLiteral
             $openingQuoteSign = $lexer->consume();
         }
 
-        while (!$lexer->isEnd()) {
+        while (true) {
+            if ($lexer->isEnd()) {
+                throw new Exception('Unclosed string literal');
+            }
+
             if ($lexer->isBackSlash() && !$willBeEscaped) {
                 $willBeEscaped = true;
                 $lexer->consume();

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -342,4 +342,54 @@ class ParserTest extends TestCase
             'selfClosing' => false
         ], $parser->parse());
     }
+
+    /**
+     * @test
+     * @expectedException \PackageFactory\Afx\Exception
+     */
+    public function shouldThrowExceptionForUnclosedTag()
+    {
+        $parser = new Parser('<div');
+        $parser->parse();
+    }
+
+    /**
+     * @test
+     * @expectedException \PackageFactory\Afx\Exception
+     */
+    public function shouldThrowExceptionForUnclosedTagWithContent()
+    {
+        $parser = new Parser('<div>foo');
+        $parser->parse();
+    }
+
+    /**
+     * @test
+     * @expectedException \PackageFactory\Afx\Exception
+     */
+    public function shouldThrowExceptionForUnclosedStringAttribute()
+    {
+        $parser = new Parser('<div foo="bar />');
+        $parser->parse();
+    }
+
+    /**
+     * @test
+     * @expectedException \PackageFactory\Afx\Exception
+     */
+    public function shouldThrowExceptionForUnclosedAttributeExpression()
+    {
+        $parser = new Parser('<div foo={bar()/>');
+        $parser->parse();
+    }
+
+    /**
+     * @test
+     * @expectedException \PackageFactory\Afx\Exception
+     */
+    public function shouldThrowExceptionForUnclosedContentExpression()
+    {
+        $parser = new Parser('<div>{bar()</div>');
+        $parser->parse();
+    }
 }


### PR DESCRIPTION
If strings, expressions or tags are not properly closed exceptions are thrown to enable graceful failing on a higher level.