### PR TITLE
FEATURE: Support html-comments in afx

### DIFF
--- a/src/Expression/Comment.php
+++ b/src/Expression/Comment.php
@@ -1,0 +1,37 @@
+<?php
+namespace PackageFactory\Afx\Expression;
+
+use PackageFactory\Afx\Exception;
+use PackageFactory\Afx\Lexer;
+
+class Comment
+{
+    public static function parse(Lexer $lexer)
+    {
+        if ($lexer->isOpeningBracket() && $lexer->peek(4) === '<!--') {
+            $lexer->consume();
+            $lexer->consume();
+            $lexer->consume();
+            $lexer->consume();
+        } else {
+            throw new Exception(sprintf('Unexpected comment start'));
+        }
+
+        $currentComment = '';
+
+        while (true) {
+            if ($lexer->isMinus() && $lexer->peek(3) === '-->') {
+                $lexer->consume();
+                $lexer->consume();
+                $lexer->consume();
+                return $currentComment;
+            }
+
+            if ($lexer->isEnd()) {
+                throw new Exception(sprintf('Comment not closed.'));
+            }
+
+            $currentComment .= $lexer->consume();
+        }
+    }
+}

--- a/src/Expression/Node.php
+++ b/src/Expression/Node.php
@@ -8,10 +8,6 @@ class Node
 {
     public static function parse(Lexer $lexer)
     {
-        while ($lexer->isWhitespace()) {
-            $lexer->consume();
-        }
-
         if ($lexer->isOpeningBracket()) {
             $lexer->consume();
         }

--- a/src/Expression/NodeList.php
+++ b/src/Expression/NodeList.php
@@ -13,25 +13,25 @@ class NodeList
         while (!$lexer->isEnd()) {
             if ($lexer->isOpeningBracket()) {
                 $lexer->consume();
-
+                if ($currentText) {
+                    $contents[] = [
+                        'type' => 'text',
+                        'payload' => $currentText
+                    ];
+                }
                 if ($lexer->isForwardSlash()) {
                     $lexer->rewind();
-                    if ($currentText) {
-                        $contents[] = [
-                            'type' => 'text',
-                            'payload' => $currentText
-                        ];
-                    }
                     return $contents;
+                } elseif ($lexer->isExclamationMark()) {
+                    $lexer->rewind();
+                    $contents[] = [
+                        'type' => 'comment',
+                        'payload' => Comment::parse($lexer)
+                    ];
+                    $currentText = '';
+                    continue;
                 } else {
                     $lexer->rewind();
-
-                    if ($currentText) {
-                        $contents[] = [
-                            'type' => 'text',
-                            'payload' => $currentText
-                        ];
-                    }
                     $contents[] = [
                         'type' => 'node',
                         'payload' => Node::parse($lexer)

--- a/src/Lexer.php
+++ b/src/Lexer.php
@@ -211,6 +211,17 @@ class Lexer
     }
 
     /**
+     * Checks if the current character is an exclamation mark
+     *
+     * @return boolean
+     */
+    public function isExclamationMark()
+    {
+        return $this->currentCharacter === '!';
+    }
+
+
+    /**
      * Checks if the iteration has ended
      *
      * @return boolean
@@ -228,6 +239,21 @@ class Lexer
     public function rewind()
     {
         $this->currentCharacter = $this->string{--$this->characterPosition};
+    }
+
+    /**
+     * Peek several characters in advance and return the next n characters
+     *
+     * @param int $characterNumber
+     * @return string|null
+     */
+    public function peek($characterNumber = 1)
+    {
+        if ($this->characterPosition < strlen($this->string) - 1) {
+            return substr($this->string, $this->characterPosition, $characterNumber);
+        } else {
+            return null;
+        }
     }
 
     /**


### PR DESCRIPTION
The parser now supports html-comments inside afx node-lists.
The comments are returned as node of type `comment` with the string between `<!--`  and `-->` as payload. All tags and expressions inside a comment are ignored.