### PR TITLE
!!! FEATURE: Support Spreads in AFX

### DIFF
--- a/src/Expression/Node.php
+++ b/src/Expression/Node.php
@@ -8,10 +8,6 @@ class Node
 {
     public static function parse(Lexer $lexer)
     {
-        while ($lexer->isWhitespace()) {
-            $lexer->consume();
-        }
-
         if ($lexer->isOpeningBracket()) {
             $lexer->consume();
         }
@@ -19,7 +15,7 @@ class Node
         $identifier = Identifier::parse($lexer);
 
         try {
-            $props = [];
+            $attributes = [];
             $children = [];
 
             if ($lexer->isWhitespace()) {
@@ -27,8 +23,17 @@ class Node
                     $lexer->consume();
                 }
                 while (!$lexer->isForwardSlash() && !$lexer->isClosingBracket()) {
-                    list($propIdentifier, $value) = Prop::parse($lexer);
-                    $props[$propIdentifier] = $value;
+                    if ($lexer->isOpeningBrace()) {
+                        $attributes[] = [
+                            'type' => 'spread',
+                            'payload' => Spread::parse($lexer)
+                        ];
+                    } else {
+                        $attributes[] = [
+                            'type' => 'prop',
+                            'payload' => Prop::parse($lexer)
+                        ];
+                    }
                     while ($lexer->isWhitespace()) {
                         $lexer->consume();
                     }
@@ -43,7 +48,7 @@ class Node
 
                     return [
                         'identifier' => $identifier,
-                        'props' => $props,
+                        'attributes' => $attributes,
                         'children' => $children,
                         'selfClosing' => true
                     ];
@@ -92,7 +97,7 @@ class Node
                 $lexer->consume();
                 return [
                     'identifier' => $identifier,
-                    'props' => $props,
+                    'attributes' => $attributes,
                     'children' => $children,
                     'selfClosing' => false
                 ];

--- a/src/Expression/Prop.php
+++ b/src/Expression/Prop.php
@@ -8,10 +8,6 @@ class Prop
 {
     public static function parse(Lexer $lexer)
     {
-        while ($lexer->isWhitespace()) {
-            $lexer->consume();
-        }
-
         $identifier = Identifier::parse($lexer);
 
         if ($lexer->isEqualSign()) {
@@ -21,14 +17,16 @@ class Prop
                 case $lexer->isDoubleQuote():
                     $value = [
                         'type' => 'string',
-                        'payload' => StringLiteral::parse($lexer)
+                        'payload' => StringLiteral::parse($lexer),
+                        'identifier' => $identifier
                     ];
                     break;
 
                 case $lexer->isOpeningBrace():
                     $value = [
                         'type' => 'expression',
-                        'payload' => Expression::parse($lexer)
+                        'payload' => Expression::parse($lexer),
+                        'identifier' => $identifier
                     ];
                     break;
                 default:
@@ -40,12 +38,13 @@ class Prop
         } elseif ($lexer->isWhiteSpace() || $lexer->isForwardSlash() || $lexer->isClosingBracket()) {
             $value = [
                 'type' => 'boolean',
-                'payload' => true
+                'payload' => true,
+                'identifier' => $identifier
             ];
         } else {
             throw new Exception(sprintf('Prop identifier "%s" is neither assignment nor boolean', $identifier));
         }
 
-        return [$identifier, $value];
+        return $value;
     }
 }

--- a/src/Expression/Spread.php
+++ b/src/Expression/Spread.php
@@ -1,0 +1,47 @@
+<?php
+namespace PackageFactory\Afx\Expression;
+
+use PackageFactory\Afx\Exception;
+use PackageFactory\Afx\Lexer;
+
+class Spread
+{
+    public static function parse(Lexer $lexer)
+    {
+        $contents = '';
+        $braceCount = 0;
+
+        if ($lexer->isOpeningBrace() && $lexer->peek(4) === '{...') {
+            $lexer->consume();
+            $lexer->consume();
+            $lexer->consume();
+            $lexer->consume();
+        } else {
+            throw new Exception('Spread without braces');
+        }
+
+        while (true) {
+            if ($lexer->isEnd()) {
+                throw new Exception(sprintf('Unfinished Spread "%s"', $contents));
+            }
+
+            if ($lexer->isOpeningBrace()) {
+                $braceCount++;
+            }
+
+            if ($lexer->isClosingBrace()) {
+                if ($braceCount === 0) {
+                    $lexer->consume();
+                    return [
+                        'type' => 'expression',
+                        'payload' => $contents
+                    ];
+                }
+
+                $braceCount--;
+            }
+
+            $contents .= $lexer->consume();
+        }
+    }
+}

--- a/src/Lexer.php
+++ b/src/Lexer.php
@@ -231,6 +231,21 @@ class Lexer
     }
 
     /**
+     * Peek several characters in advance and return the next n characters
+     *
+     * @param int $characterNumber
+     * @return string|null
+     */
+    public function peek($characterNumber = 1)
+    {
+        if ($this->characterPosition < strlen($this->string) - 1) {
+            return substr($this->string, $this->characterPosition, $characterNumber);
+        } else {
+            return null;
+        }
+    }
+
+    /**
      * Returns the current character and moves one step forward
      *
      * @return string|null

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -51,7 +51,7 @@ class ParserTest extends TestCase
                     'type' => 'node',
                     'payload' => [
                         'identifier' => 'div',
-                        'props' => [],
+                        'attributes' => [],
                         'children' => [],
                         'selfClosing' => false
                     ]
@@ -76,7 +76,7 @@ class ParserTest extends TestCase
                     'type' => 'node',
                     'payload' => [
                         'identifier' => 'div',
-                        'props' => [],
+                        'attributes' => [],
                         'children' => [],
                         'selfClosing' => true
                     ]
@@ -99,7 +99,7 @@ class ParserTest extends TestCase
                     'type' => 'node',
                     'payload' => [
                         'identifier' => 'div',
-                        'props' => [],
+                        'attributes' => [],
                         'children' => [],
                         'selfClosing' => true
                     ]
@@ -122,7 +122,7 @@ class ParserTest extends TestCase
                     'type' => 'node',
                     'payload' => [
                         'identifier' => 'div',
-                        'props' => [],
+                        'attributes' => [],
                         'children' => [],
                         'selfClosing' => false
                     ]
@@ -145,10 +145,14 @@ class ParserTest extends TestCase
                     'type' => 'node',
                     'payload' => [
                         'identifier' => 'div',
-                        'props' => [
-                            'prop' => [
-                                'type' => 'string',
-                                'payload' => 'value'
+                        'attributes' => [
+                            [
+                                'type' => 'prop',
+                                'payload' => [
+                                    'type' => 'string',
+                                    'payload' => 'value',
+                                    'identifier' => 'prop'
+                                ]
                             ]
                         ],
                         'children' => [],
@@ -173,14 +177,22 @@ class ParserTest extends TestCase
                     'type' => 'node',
                     'payload' => [
                         'identifier' => 'div',
-                        'props' => [
-                            'prop' => [
-                                'type' => 'string',
-                                'payload' => 'value'
+                        'attributes' => [
+                            [
+                                'type' => 'prop',
+                                'payload' => [
+                                    'type' => 'string',
+                                    'payload' => 'value',
+                                    'identifier' => 'prop'
+                                ]
                             ],
-                            'anotherProp' => [
-                                'type' => 'string',
-                                'payload' => 'Another Value'
+                            [
+                                'type' => 'prop',
+                                'payload' => [
+                                    'type' => 'string',
+                                    'payload' => 'Another Value',
+                                    'identifier' => 'anotherProp'
+                                ]
                             ]
                         ],
                         'children' => [],
@@ -205,14 +217,100 @@ class ParserTest extends TestCase
                     'type' => 'node',
                     'payload' => [
                         'identifier' => 'div',
-                        'props' => [
-                            'prop' => [
-                                'type' => 'string',
-                                'payload' => 'value'
+                        'attributes' => [
+                            [
+                                'type' => 'prop',
+                                'payload' => [
+                                    'type' => 'string',
+                                    'payload' => 'value',
+                                    'identifier' => 'prop'
+                                ]
                             ],
-                            'anotherProp' => [
-                                'type' => 'string',
-                                'payload' => 'Another Value'
+                            [
+                                'type' => 'prop',
+                                'payload' => [
+                                    'type' => 'string',
+                                    'payload' => 'Another Value',
+                                    'identifier' => 'anotherProp'
+                                ]
+                            ]
+                        ],
+                        'children' => [],
+                        'selfClosing' => true
+                    ]
+                ]
+            ],
+            $parser->parse()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function shouldParseSpreads()
+    {
+        $parser = new Parser('<div {...item} />');
+
+        $this->assertEquals(
+            [
+                [
+                    'type' => 'node',
+                    'payload' => [
+                        'identifier' => 'div',
+                        'attributes' => [
+                            [
+                                'type' => 'spread',
+                                'payload' => [
+                                    'type' => 'expression',
+                                    'payload' => 'item'
+                                ]
+                            ]
+                        ],
+                        'children' => [],
+                        'selfClosing' => true
+                    ]
+                ]
+            ],
+            $parser->parse()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function shouldParseSpreadsAndPropsInOrder()
+    {
+        $parser = new Parser('<div foo="string" {...item} bar={expression} />');
+
+        $this->assertEquals(
+            [
+                [
+                    'type' => 'node',
+                    'payload' => [
+                        'identifier' => 'div',
+                        'attributes' => [
+                            [
+                                'type' => 'prop',
+                                'payload' => [
+                                    'type' => 'string',
+                                    'payload' => 'string',
+                                    'identifier' => 'foo'
+                                ]
+                            ],
+                            [
+                                'type' => 'spread',
+                                'payload' => [
+                                    'type' => 'expression',
+                                    'payload' => 'item',
+                                ]
+                            ],
+                            [
+                                'type' => 'prop',
+                                'payload' => [
+                                    'type' => 'expression',
+                                    'payload' => 'expression',
+                                    'identifier' => 'bar'
+                                ]
                             ]
                         ],
                         'children' => [],
@@ -237,7 +335,7 @@ class ParserTest extends TestCase
                     'type' => 'node',
                     'payload' => [
                         'identifier' => 'div',
-                        'props' => [],
+                        'attributes' => [],
                         'children' => [],
                         'selfClosing' => false
                     ]
@@ -246,7 +344,7 @@ class ParserTest extends TestCase
                     'type' => 'node',
                     'payload' => [
                         'identifier' => 'span',
-                        'props' => [],
+                        'attributes' => [],
                         'children' => [],
                         'selfClosing' => false
                     ]
@@ -255,7 +353,7 @@ class ParserTest extends TestCase
                     'type' => 'node',
                     'payload' => [
                         'identifier' => 'h1',
-                        'props' => [],
+                        'attributes' => [],
                         'children' => [],
                         'selfClosing' => false
                     ]
@@ -282,7 +380,7 @@ class ParserTest extends TestCase
                     'type' => 'node',
                     'payload' => [
                         'identifier' => 'div',
-                        'props' => [],
+                        'attributes' => [],
                         'children' => [],
                         'selfClosing' => false
                     ]
@@ -309,7 +407,7 @@ class ParserTest extends TestCase
                     'type' => 'node',
                     'payload' => [
                         'identifier' => 'div',
-                        'props' => [],
+                        'attributes' => [],
                         'children' => [],
                         'selfClosing' => false
                     ]
@@ -322,7 +420,7 @@ class ParserTest extends TestCase
                     'type' => 'node',
                     'payload' => [
                         'identifier' => 'span',
-                        'props' => [],
+                        'attributes' => [],
                         'children' => [],
                         'selfClosing' => false
                     ]
@@ -349,7 +447,7 @@ class ParserTest extends TestCase
                     'type' => 'node',
                     'payload' => [
                         'identifier' => 'div',
-                        'props' => [],
+                        'attributes' => [],
                         'children' => [],
                         'selfClosing' => false
                     ]
@@ -376,14 +474,22 @@ class ParserTest extends TestCase
                     'type' => 'node',
                     'payload' => [
                         'identifier' => 'div',
-                        'props' => [
-                            'prop-1' => [
-                                'type' => 'string',
-                                'payload' => 'value'
+                        'attributes' => [
+                            [
+                                'type' => 'prop',
+                                'payload' => [
+                                    'type' => 'string',
+                                    'payload' => 'value',
+                                    'identifier' => 'prop-1'
+                                ]
                             ],
-                            'prop-2' => [
-                                'type' => 'string',
-                                'payload' => 'Another Value'
+                            [
+                                'type' => 'prop',
+                                'payload' => [
+                                    'type' => 'string',
+                                    'payload' => 'Another Value',
+                                    'identifier' => 'prop-2'
+                                ]
                             ]
                         ],
                         'children' => [],
@@ -408,7 +514,7 @@ class ParserTest extends TestCase
                     'type' => 'node',
                     'payload' => [
                         'identifier' => 'div',
-                        'props' => [],
+                        'attributes' => [],
                         'children' => [],
                         'selfClosing' => false
                     ]
@@ -431,7 +537,7 @@ class ParserTest extends TestCase
                     'type' => 'node',
                     'payload' => [
                         'identifier' => 'div',
-                        'props' => [],
+                        'attributes' => [],
                         'children' => [
                             [
                                 'type' => 'text',
@@ -459,13 +565,13 @@ class ParserTest extends TestCase
                     'type' => 'node',
                     'payload' => [
                         'identifier' => 'div',
-                        'props' => [],
+                        'attributes' => [],
                         'children' => [
                             [
                                 'type' => 'node',
                                 'payload' => [
                                     'identifier' => 'input',
-                                    'props' => [],
+                                    'attributes' => [],
                                     'children' => [],
                                     'selfClosing' => true
                                 ]
@@ -492,19 +598,19 @@ class ParserTest extends TestCase
                     'type' => 'node',
                     'payload' => [
                         'identifier' => 'article',
-                        'props' => [],
+                        'attributes' => [],
                         'children' => [
                             [
                                 'type' => 'node',
                                 'payload' => [
                                     'identifier' => 'header',
-                                    'props' => [],
+                                    'attributes' => [],
                                     'children' => [
                                         [
                                             'type' => 'node',
                                             'payload' => [
                                                 'identifier' => 'div',
-                                                'props' => [],
+                                                'attributes' => [],
                                                 'children' => [
                                                     [
                                                         'type' => 'text',
@@ -522,7 +628,7 @@ class ParserTest extends TestCase
                                 'type' => 'node',
                                 'payload' => [
                                     'identifier' => 'div',
-                                    'props' => [],
+                                    'attributes' => [],
                                     'children' => [
                                         [
                                             'type' => 'text',
@@ -536,13 +642,13 @@ class ParserTest extends TestCase
                                 'type' => 'node',
                                 'payload' => [
                                     'identifier' => 'footer',
-                                    'props' => [],
+                                    'attributes' => [],
                                     'children' => [
                                         [
                                             'type' => 'node',
                                             'payload' => [
                                                 'identifier' => 'div',
-                                                'props' => [],
+                                                'attributes' => [],
                                                 'children' => [
                                                     [
                                                         'type' => 'text',
@@ -587,7 +693,7 @@ class ParserTest extends TestCase
                     'type' => 'node',
                     'payload' => [
                         'identifier' => 'div',
-                        'props' => [],
+                        'attributes' => [],
                         'children' => [
                             [
                                 'type' => 'text',
@@ -598,7 +704,7 @@ class ParserTest extends TestCase
                                 'type' => 'node',
                                 'payload' => [
                                     'identifier' => 'input',
-                                    'props' => [],
+                                    'attributes' => [],
                                     'children' => [],
                                     'selfClosing' => true
                                 ]
@@ -612,7 +718,7 @@ class ParserTest extends TestCase
                                 'type' => 'node',
                                 'payload' => [
                                     'identifier' => 'label',
-                                    'props' => [],
+                                    'attributes' => [],
                                     'children' => [
                                         [
                                             'type' => 'text',
@@ -678,7 +784,7 @@ class ParserTest extends TestCase
      */
     public function shouldThrowExceptionForUnclosedAttributeExpression()
     {
-        $parser = new Parser('<div foo={bar()/>');
+        $parser = new Parser('<div foo={bar() />');
         $parser->parse();
     }
 
@@ -689,6 +795,16 @@ class ParserTest extends TestCase
     public function shouldThrowExceptionForUnclosedContentExpression()
     {
         $parser = new Parser('<div>{bar()</div>');
+        $parser->parse();
+    }
+
+    /**
+     * @test
+     * @expectedException \PackageFactory\Afx\Exception
+     */
+    public function shouldThrowExceptionForUnclosedSpreadExpression()
+    {
+        $parser = new Parser('<div {...bar() />');
         $parser->parse();
     }
 }


### PR DESCRIPTION
The changes the way props are returned, the props and spreads are now all returned as `attributes` of an afx-node. The attributes can be of type `string`, `expression` and `spread` the first two contain an `identifier` with the name of the prop. Spreads do not recieve an identifier but only the expression as payload.